### PR TITLE
GHA: Fix up OS matrix

### DIFF
--- a/.github/workflows/awb.yml
+++ b/.github/workflows/awb.yml
@@ -9,15 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows-version: ['windows-latest', 'windows-2016']
+        windows-version: ['windows-2019']
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '4.5.2'
       - name: Build
         run: |
             MSBuild.exe $Env:GITHUB_WORKSPACE\'AutoWikiBrowser no plugins.sln' /p:Configuration=Release

--- a/.github/workflows/awb.yml
+++ b/.github/workflows/awb.yml
@@ -17,7 +17,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '4.5'
+          dotnet-version: '4.5.2'
       - name: Build
         run: |
             MSBuild.exe $Env:GITHUB_WORKSPACE\'AutoWikiBrowser no plugins.sln' /p:Configuration=Release

--- a/.github/workflows/awb.yml
+++ b/.github/workflows/awb.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - uses: actions/setup-dotnet@v3
-          with:
-           dotnet-version: '4.5'
+        with:
+          dotnet-version: '4.5'
       - name: Build
         run: |
             MSBuild.exe $Env:GITHUB_WORKSPACE\'AutoWikiBrowser no plugins.sln' /p:Configuration=Release

--- a/.github/workflows/awb.yml
+++ b/.github/workflows/awb.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
+      - uses: actions/setup-dotnet@v3
+          with:
+           dotnet-version: '4.5'
       - name: Build
         run: |
             MSBuild.exe $Env:GITHUB_WORKSPACE\'AutoWikiBrowser no plugins.sln' /p:Configuration=Release


### PR DESCRIPTION
This PR gets us back up and going for a bit, as it does the following:

* Removes `windows-latest` which wasn't working with this particular project
* Removes `windows-2016` which was deprecated some time ago
* Adds `windows-2019` which used to actually be `windows-2019` but is now `windows-2022`